### PR TITLE
Make random randomed

### DIFF
--- a/lua/org-roam/core/utils/random.lua
+++ b/lua/org-roam/core/utils/random.lua
@@ -6,11 +6,17 @@
 
 ---@class org-roam.core.utils.Random
 local M = {}
+local seeded = false
 
 ---@param m integer
 ---@param n integer
 ---@return integer
 function M.random(m, n)
+    if seeded == false then
+        -- https://www.lua-users.org/wiki/MathLibraryTutorial
+        math.randomseed(tonumber(tostring(os.time()):reverse():sub(1,6)))
+        seeded = true
+    end
     return math.random(m, n)
 end
 


### PR DESCRIPTION
Hey, me again. I've noticed another problem that when use internal uuid generator, uuid will always be a fix sequence, which same uuid cause a failed write to db.  After a little dig in, I found [this wiki](https://www.lua-users.org/wiki/MathLibraryTutorial). As this wiki says:
>math.random() generates pseudo-random numbers uniformly distributed.

We need use math.randomseed() to setup a seed to make random more random.

I add this to `M.random`, so that we don't need any other method like `M.init_random`.
Feel free to modify the PR if this don't meets your design : )