### PR TITLE
fix: resolve links when getting MATCHED_FG highlight

### DIFF
--- a/lua/org-roam/core/ui/select.lua
+++ b/lua/org-roam/core/ui/select.lua
@@ -59,7 +59,7 @@ local init_highlights = (function()
             -- Define custom highlight group for matching
             local normal_hl = vim.api.nvim_get_hl(0, { name = HIGHLIGHTS.NORMAL })
             local selected_hl = vim.api.nvim_get_hl(0, { name = HIGHLIGHTS.SELECTED })
-            local fg = vim.api.nvim_get_hl(0, { name = HIGHLIGHTS.MATCHED_FG }).fg
+            local fg = vim.api.nvim_get_hl(0, { name = HIGHLIGHTS.MATCHED_FG, link = false }).fg
             vim.api.nvim_set_hl(
                 0,
                 HIGHLIGHTS.MATCHED,


### PR DESCRIPTION
My colorscheme sets WarningMsg as a link, so `nvim_get_hl` would just return the link object, for which `fg`would be `nil`. This would break all select UIs with an error when nil is passed to `string.format`.

For reference: The output of `nvim_get_hl`:
```
{
  link = "GruvboxRedBold"
}
```

With this fix, it returns the actual highlight, including the foreground color. That resolves the issue.