### PR TITLE
fix(select-ui): set nowrap on window to prevent visual overflow

### DIFF
--- a/lua/org-roam/core/ui/select.lua
+++ b/lua/org-roam/core/ui/select.lua
@@ -306,6 +306,7 @@ function M:open()
             },
             winopts = {
                 cursorline = false,
+                wrap = false,
             },
             components = {
                 function()


### PR DESCRIPTION
When calculating the padding for the selection UI, the window width includes the signcolumn, if it's open. In combination with `wrap`, this leads to seemingly blank lines between items (the red is a highlight for trailing whitespace):

![2024-05-31T22-11-13](https://github.com/chipsenkbeil/org-roam.nvim/assets/9082925/2d605632-a1d6-47b4-8bf3-ea8638e16b79)

I couldn't find a way to get the signcolumn width, but disabling line wrapping seems like an OK workaround.

This may change how very long titles are displayed, as these will now be visually truncated. If that's an issue, feel free to close this. I can also just fix this in my local configuration with filetype options for the org-roam-select.