### PR TITLE
feat: provide keybinding prefix option

### DIFF
--- a/DOCS.org
+++ b/DOCS.org
@@ -74,6 +74,35 @@
 
    Configuration settings used to specify keybindings.
 
+*** prefix
+
+    Sets an overall prefix, to define common leading keystrokes for other
+    bindings. Defaults to =<Leader>n=.
+
+    #+begin_src lua
+    require("org-roam").setup({
+      bindings = {
+        prefix = "<LocalLeader>n",
+      },
+    })
+    #+end_src
+
+    It can be used in other bindings with =<prefix>=:
+
+    #+begin_src lua
+    require("org-roam").setup({
+      bindings = {
+        prefix = "<LocalLeader>n",
+        -- ...
+        add_alias = "<prefix>A", -- add alias is now bound to <LocalLeader>nA
+      },
+    })
+    #+end_src
+
+    All default keybindings use it, so if you just want to change =<Leader>n= to
+    something else, instead of redefining them all manually, just set
+    =bindings.prefix= to your preference. See also [[*Modifying bindings]].
+
 *** add alias
 
     Adds an alias to the node under cursor.
@@ -810,6 +839,9 @@
   | toggle_roam_buffer       | =<Leader>nl=  | Toggles the org-roam node-view buffer for the node under cursor.          |
   | toggle_roam_buffer_fixed | =<Leader>nb=  | Toggles a fixed org-roam node-view buffer for a selected node.            |
 
+  All these bindings use by default the [[*prefix]] alias and can be changed all
+  at once by modifying ~bindings.prefix~.
+
 ** Dailies Extension
 
    | Name              | Keybinding    | Description                                     |
@@ -826,27 +858,56 @@
    | goto_tomorrow     | =<Leader>ndt= | Navigate to tomorrow's note.                    |
    | goto_yesterday    | =<Leader>ndy= | Navigate to yesterday's note.                   |
 
+   All these bindings use by default the [[*prefix]] alias and can be changed all
+   at once by modifying ~bindings.prefix~.
+
 ** Modifying bindings
 
-  Bindings can be changed during configuration by overwriting them within the =bindings= table:
+   Bindings can be changed during configuration by overwriting them within the
+   =bindings= table: 
 
-  #+begin_src lua
-  require("org-roam").setup({
-    -- ...
-    bindings = {
-      capture = "<LocalLeader>nc",
-    },
-  })
-  #+end_src
+   #+begin_src lua
+   require("org-roam").setup({
+     -- ...
+     bindings = {
+       capture = "<LocalLeader>nc" -- remaps from <Leader>nc to <LocalLeader>nc
+     },
+   })
+   #+end_src
 
-  To disable all bindings, set the =bindings= field to =false=:
+   We use a common [[*prefix]] to define the leading keystrokes in every
+   mapping, which are by default =<Leader>n=. If you only want to adjust these,
+   you can do so by setting =bindings.prefix=:
 
-  #+begin_src lua
-  require("org-roam").setup({
-    -- ...
-    bindings = false,
-  })
-  #+end_src
+   #+begin_src lua
+   require("org-roam").setup({
+     -- ...
+     bindings = {
+       prefix = "<LocalLeader>n", -- replaces <Leader>n in every binding with <LocalLeader>n
+     },
+   })
+   #+end_src
+
+   The [[*prefix]] can also be reused in self-defined bindings:
+
+   #+begin_src lua
+   require("org-roam").setup({
+     -- ...
+     bindings = {
+       toggle_roam_buffer = "<prefix>t.",       -- replaces <Leader>nl with <Leader>nt.
+       toggle_roam_buffer_fixed = "<prefix>tf", -- replaces <Leader>nb with <Leader>ntf
+     },
+   })
+   #+end_src
+
+   To disable all bindings, set the =bindings= field to =false=:
+
+   #+begin_src lua
+   require("org-roam").setup({
+     -- ...
+     bindings = false,
+   })
+   #+end_src
 
 ** Coming from Emacs
 

--- a/lua/org-roam/config.lua
+++ b/lua/org-roam/config.lua
@@ -19,50 +19,52 @@ local DEFAULT_CONFIG = {
     ---Bindings associated with org-roam functionality.
     ---@class org-roam.config.Bindings
     bindings = {
+        ---Adjusts the prefix for every keybinding. Can be used in keybindings with <prefix>.
+        prefix = "<Leader>n",
         ---Adds an alias to the node under cursor.
-        add_alias = "<Leader>naa",
+        add_alias = "<prefix>aa",
 
         ---Adds an origin to the node under cursor.
-        add_origin = "<Leader>noa",
+        add_origin = "<prefix>oa",
 
         ---Opens org-roam capture window.
-        capture = "<Leader>nc",
+        capture = "<prefix>c",
 
         ---Completes the node under cursor.
-        complete_at_point = "<Leader>n.",
+        complete_at_point = "<prefix>.",
 
         ---Finds node and moves to it.
-        find_node = "<Leader>nf",
+        find_node = "<prefix>f",
 
         ---Goes to the next node sequentially based on origin of the node under cursor.
         ---
         ---If more than one node has the node under cursor as its origin, a selection
         ---dialog is displayed to choose the node.
-        goto_next_node = "<Leader>nn",
+        goto_next_node = "<prefix>n",
 
         ---Goes to the previous node sequentially based on origin of the node under cursor.
-        goto_prev_node = "<Leader>np",
+        goto_prev_node = "<prefix>p",
 
         ---Inserts node at cursor position.
-        insert_node = "<Leader>ni",
+        insert_node = "<prefix>i",
 
         ---Inserts node at cursor position without opening capture buffer.
-        insert_node_immediate = "<Leader>nm",
+        insert_node_immediate = "<prefix>m",
 
         ---Opens the quickfix menu for backlinks to the current node under cursor.
-        quickfix_backlinks = "<Leader>nq",
+        quickfix_backlinks = "<prefix>q",
 
         ---Removes an alias from the node under cursor.
-        remove_alias = "<Leader>nar",
+        remove_alias = "<prefix>ar",
 
         ---Removes the origin from the node under cursor.
-        remove_origin = "<Leader>nor",
+        remove_origin = "<prefix>or",
 
         ---Toggles the org-roam node-view buffer for the node under cursor.
-        toggle_roam_buffer = "<Leader>nl",
+        toggle_roam_buffer = "<prefix>l",
 
         ---Toggles a fixed org-roam node-view buffer for a selected node.
-        toggle_roam_buffer_fixed = "<Leader>nb",
+        toggle_roam_buffer_fixed = "<prefix>b",
     },
 
     ---Settings associated with org-roam capture logic.
@@ -108,37 +110,37 @@ local DEFAULT_CONFIG = {
             ---@class org-roam.config.extensions.dailies.Bindings
             bindings = {
                 ---Capture a specific date's note.
-                capture_date = "<Leader>ndD",
+                capture_date = "<prefix>dD",
 
                 ---Capture today's note.
-                capture_today = "<Leader>ndN",
+                capture_today = "<prefix>dN",
 
                 ---Capture tomorrow's note.
-                capture_tomorrow = "<Leader>ndT",
+                capture_tomorrow = "<prefix>dT",
 
                 ---Capture yesterday's note.
-                capture_yesterday = "<Leader>ndY",
+                capture_yesterday = "<prefix>dY",
 
                 ---Navigate to dailies note directory.
-                find_directory = "<Leader>nd.",
+                find_directory = "<prefix>d.",
 
                 ---Navigate to specific date's note.
-                goto_date = "<Leader>ndd",
+                goto_date = "<prefix>dd",
 
                 ---Navigate to the next note in date sequence.
-                goto_next_date = "<Leader>ndf",
+                goto_next_date = "<prefix>df",
 
                 ---Navigate to the previous note in date sequence.
-                goto_prev_date = "<Leader>ndb",
+                goto_prev_date = "<prefix>db",
 
                 ---Navigate to today's note.
-                goto_today = "<Leader>ndn",
+                goto_today = "<prefix>dn",
 
                 ---Navigate to tomorrow's note.
-                goto_tomorrow = "<Leader>ndt",
+                goto_tomorrow = "<prefix>dt",
 
                 ---Navigate to yesterday's note.
-                goto_yesterday = "<Leader>ndy",
+                goto_yesterday = "<prefix>dy",
             },
 
             ---Settings tied to org-roam dailies capture templates.

--- a/lua/org-roam/setup/keybindings.lua
+++ b/lua/org-roam/setup/keybindings.lua
@@ -20,7 +20,8 @@ local notify = require("org-roam.core.ui.notify")
 ---@param lhs string|{lhs:string, modes:org-roam.config.NvimMode[]}|nil
 ---@param desc string
 ---@param cb fun()
-local function assign(lhs, desc, cb)
+---@param prefix string?
+local function assign(lhs, desc, cb, prefix)
     if type(cb) ~= "function" then
         return
     end
@@ -36,6 +37,10 @@ local function assign(lhs, desc, cb)
 
     if vim.trim(lhs) == "" or #modes == 0 then
         return
+    end
+
+    if prefix then
+        lhs = lhs:gsub("<prefix>", prefix)
     end
 
     for _, mode in ipairs(modes) do
@@ -82,29 +87,31 @@ end
 local function assign_core_keybindings(roam)
     -- User can remove all bindings by setting this to nil
     local bindings = roam.config.bindings or {}
+    local prefix = roam.config.bindings.prefix
 
     assign(bindings.add_alias, "Adds an alias to the roam node under cursor", function()
         roam.api.add_alias()
-    end)
+    end, prefix)
 
     assign(bindings.remove_alias, "Removes an alias from the roam node under cursor", function()
         roam.api.remove_alias()
-    end)
+    end, prefix)
 
     assign(bindings.add_origin, "Adds an origin to the roam node under cursor", function()
         roam.api.add_origin()
-    end)
+    end, prefix)
 
     assign(bindings.remove_origin, "Removes the origin from the roam node under cursor", function()
         roam.api.remove_origin()
-    end)
+    end, prefix)
 
     assign(
         bindings.goto_prev_node,
         "Goes to the previous node sequentially based on origin of the node under cursor",
         function()
             roam.api.goto_prev_node()
-        end
+        end,
+        prefix
     )
 
     assign(
@@ -112,7 +119,8 @@ local function assign_core_keybindings(roam)
         "Goes to the next node sequentially based on origin of the node under cursor",
         function()
             roam.api.goto_next_node()
-        end
+        end,
+        prefix
     )
 
     assign(bindings.quickfix_backlinks, "Open quickfix of backlinks for org-roam node under cursor", function()
@@ -120,24 +128,24 @@ local function assign_core_keybindings(roam)
             backlinks = true,
             show_preview = true,
         })
-    end)
+    end, prefix)
 
     assign(bindings.toggle_roam_buffer, "Toggles org-roam buffer for node under cursor", function()
         roam.ui.toggle_node_buffer({
             focus = roam.config.ui.node_buffer.focus_on_toggle,
         })
-    end)
+    end, prefix)
 
     assign(bindings.toggle_roam_buffer_fixed, "Toggles org-roam buffer for a specific node, not changing", function()
         roam.ui.toggle_node_buffer({
             fixed = true,
             focus = roam.config.ui.node_buffer.focus_on_toggle,
         })
-    end)
+    end, prefix)
 
     assign(bindings.complete_at_point, "Completes link to a node based on expression under cursor", function()
         roam.api.complete_node()
-    end)
+    end, prefix)
 
     assign({ lhs = bindings.capture, modes = { "n", "v" } }, "Opens org-roam capture window", function()
         local results = get_visual_selection(roam)
@@ -150,7 +158,7 @@ local function assign_core_keybindings(roam)
         roam.api.capture_node({
             title = title,
         })
-    end)
+    end, prefix)
 
     assign(
         { lhs = bindings.find_node, modes = { "n", "v" } },
@@ -166,7 +174,8 @@ local function assign_core_keybindings(roam)
             roam.api.find_node({
                 title = title,
             })
-        end
+        end,
+        prefix
     )
 
     assign(
@@ -185,7 +194,8 @@ local function assign_core_keybindings(roam)
                 title = title,
                 ranges = ranges,
             })
-        end
+        end,
+        prefix
     )
 
     assign(
@@ -205,7 +215,8 @@ local function assign_core_keybindings(roam)
                 title = title,
                 ranges = ranges,
             })
-        end
+        end,
+        prefix
     )
 end
 
@@ -213,50 +224,51 @@ end
 local function assign_dailies_keybindings(roam)
     -- User can remove all bindings by setting this to nil
     local bindings = roam.config.extensions.dailies.bindings or {}
+    local prefix = roam.config.bindings.prefix
 
     assign(bindings.capture_date, "Capture a specific date's note", function()
         roam.ext.dailies.capture_date()
-    end)
+    end, prefix)
 
     assign(bindings.capture_today, "Capture today's note", function()
         roam.ext.dailies.capture_today()
-    end)
+    end, prefix)
 
     assign(bindings.capture_tomorrow, "Capture tomorrow's note", function()
         roam.ext.dailies.capture_tomorrow()
-    end)
+    end, prefix)
 
     assign(bindings.capture_yesterday, "Capture yesterday's note", function()
         roam.ext.dailies.capture_yesterday()
-    end)
+    end, prefix)
 
     assign(bindings.find_directory, "Navigate to dailies note directory", function()
         roam.ext.dailies.find_directory()
-    end)
+    end, prefix)
 
     assign(bindings.goto_date, "Navigate to a specific date's note", function()
         roam.ext.dailies.goto_date()
-    end)
+    end, prefix)
 
     assign(bindings.goto_today, "Navigate to today's note", function()
         roam.ext.dailies.goto_today()
-    end)
+    end, prefix)
 
     assign(bindings.goto_tomorrow, "Navigate to tomorrow's note", function()
         roam.ext.dailies.goto_tomorrow()
-    end)
+    end, prefix)
 
     assign(bindings.goto_yesterday, "Navigate to yesterday's note", function()
         roam.ext.dailies.goto_yesterday()
-    end)
+    end, prefix)
 
     assign(bindings.goto_next_date, "Navigate to the next available note", function()
         roam.ext.dailies.goto_next_date()
-    end)
+    end, prefix)
 
     assign(bindings.goto_prev_date, "Navigate to the previous available note", function()
         roam.ext.dailies.goto_prev_date()
-    end)
+    end, prefix)
 end
 
 ---@param roam OrgRoam

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -22,6 +22,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -47,6 +48,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.add_alias, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         assert.are.same({
@@ -73,6 +75,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -98,6 +101,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.remove_alias, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         assert.are.same({
@@ -123,6 +127,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -148,6 +153,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.add_origin, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         assert.are.same({
@@ -175,6 +181,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -196,6 +203,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.remove_origin, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         assert.are.same({
@@ -232,6 +240,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -242,6 +251,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.goto_prev_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Review that we moved to the origin
@@ -268,6 +278,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -278,6 +289,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.goto_next_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Review that we moved to the next node
@@ -316,6 +328,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -331,6 +344,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.goto_next_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Review that we moved to the next node
@@ -358,6 +372,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -368,6 +383,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.quickfix_backlinks, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify the quickfix contents
@@ -388,6 +404,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -398,6 +415,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.toggle_roam_buffer, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -427,6 +445,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -439,6 +458,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.toggle_roam_buffer_fixed, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -468,6 +488,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -484,6 +505,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.complete_at_point, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -506,6 +528,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -523,6 +546,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.capture, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Capture the lines of the capture buffer
@@ -560,6 +584,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -586,6 +611,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.capture, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Capture the lines of the capture buffer
@@ -623,6 +649,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -635,6 +662,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.find_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we loaded the buffer for the selected node
@@ -662,6 +690,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -687,6 +716,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.find_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we loaded the buffer for the selected node
@@ -714,6 +744,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -726,6 +757,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.insert_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we inserted the link
@@ -746,6 +778,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -771,6 +804,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.insert_node, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we inserted the link, replacing the visual selection
@@ -791,6 +825,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -803,6 +838,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.insert_node_immediate, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we inserted the link to the new node
@@ -823,6 +859,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -843,6 +880,7 @@ describe("org-roam.setup.keybindings", function()
         -- Trigger the keybinding and wait a bit
         utils.trigger_mapping("n", roam.config.bindings.insert_node_immediate, {
             wait = utils.wait_time(),
+            prefix = prefix,
         })
 
         -- Verify we inserted the link to the new node

--- a/spec/utils.lua
+++ b/spec/utils.lua
@@ -312,6 +312,9 @@ end
 ---@param opts? {buf?:integer, wait?:integer}
 function M.trigger_mapping(mode, lhs, opts)
     opts = opts or {}
+    if opts.prefix then
+        lhs = lhs:gsub("<prefix>", opts.prefix)
+    end
 
     local exists, mapping
     if opts.buf then


### PR DESCRIPTION
Allows to conveniently rebind the prefix of most of the plugins key mappings without having to change them all explicitly. Resolves #46.