### PR TITLE
Open calendar at current day

### DIFF
--- a/lua/org-roam/extensions/dailies.lua
+++ b/lua/org-roam/extensions/dailies.lua
@@ -286,7 +286,7 @@ return function(roam)
         if type(date) == "table" then
             date_promise = Promise.resolve(date)
         else
-            date_promise = Calendar.new({ on_day = make_render_on_day(roam) }):open()
+            date_promise = Calendar.new({ date = Date.today(), on_day = make_render_on_day(roam) }):open()
         end
 
         return date_promise:next(function(date)


### PR DESCRIPTION
This little tweak opens the calendar at the current day, which is more convenient in my opinion and aligns with how the calendar in Orgmode works.