### PR TITLE
fix: type error in case `config.bindings = false`.

### DIFF
--- a/DOCS.org
+++ b/DOCS.org
@@ -904,7 +904,7 @@
 ** Modifying bindings
 
    Bindings can be changed during configuration by overwriting them within the
-   =bindings= table: 
+   =bindings= table:
 
    #+begin_src lua
    require("org-roam").setup({
@@ -940,12 +940,27 @@
    })
    #+end_src
 
-   To disable all bindings, set the =bindings= field to =false=:
+   To disable all bindings (including those of extensions), set the =bindings=
+   field to =false=:
 
    #+begin_src lua
    require("org-roam").setup({
      -- ...
      bindings = false,
+   })
+   #+end_src
+
+   To disable only the bindings of an extension, set its respective =bindings=
+   field to =false=:
+
+   #+begin_src lua
+   require("org-roam").setup({
+     -- ...
+     extensions = {
+       dailies = {
+         bindings = false,
+       }
+     },
    })
    #+end_src
 

--- a/lua/org-roam/setup/keybindings.lua
+++ b/lua/org-roam/setup/keybindings.lua
@@ -85,9 +85,9 @@ end
 
 ---@param roam OrgRoam
 local function assign_core_keybindings(roam)
-    -- User can remove all bindings by setting this to nil
+    -- User can remove all bindings by setting this to false
     local bindings = roam.config.bindings or {}
-    local prefix = roam.config.bindings.prefix
+    local prefix = bindings.prefix
 
     assign(bindings.add_alias, "Adds an alias to the roam node under cursor", function()
         roam.api.add_alias()
@@ -222,9 +222,14 @@ end
 
 ---@param roam OrgRoam
 local function assign_dailies_keybindings(roam)
-    -- User can remove all bindings by setting this to nil
+    -- User can remove all bindings by setting this to false
     local bindings = roam.config.extensions.dailies.bindings or {}
-    local prefix = roam.config.bindings.prefix
+    -- If core bindings are disabled, extension bindings are disabled as well.
+    local core_bindings = roam.config.bindings
+    if not core_bindings then
+        return
+    end
+    local prefix = core_bindings.prefix
 
     assign(bindings.capture_date, "Capture a specific date's note", function()
         roam.ext.dailies.capture_date()

--- a/lua/org-roam/setup/keybindings.lua
+++ b/lua/org-roam/setup/keybindings.lua
@@ -33,6 +33,9 @@ local function assign(lhs, desc, cb, prefix)
     if type(lhs) == "table" then
         modes = lhs.modes
         lhs = lhs.lhs
+        if not lhs then
+            return
+        end
     end
 
     if vim.trim(lhs) == "" or #modes == 0 then

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -889,4 +889,84 @@ describe("org-roam.setup.keybindings", function()
         assert(id, "could not find id of newly-inserted node")
         assert.are.same({ "some [[id:" .. id .. "][series of text on multiple]] lines" }, lines)
     end)
+
+    it("bindings can be disabled by setting them to false", function()
+        -- Remove binding created by other tests.
+        local binding = "<Leader>nc"
+        if utils.global_mapping_exists("n", binding) then
+            vim.api.nvim_del_keymap("n", binding)
+        end
+
+        -- Configure plugin to set up _no_ key bindings.
+        utils.init_plugin({
+            setup = { bindings = false },
+        })
+
+        local exists = utils.global_mapping_exists("n", binding)
+        assert(not exists, "found global mapping " .. binding .. " despite disabling it")
+    end)
+
+    it("default binding for capture is <Leader>nc", function()
+        -- Remove binding created by other tests.
+        local binding = "<Leader>nc"
+        if utils.global_mapping_exists("n", binding) then
+            vim.api.nvim_del_keymap("n", binding)
+        end
+
+        -- Configure plugin to set up key bindings.
+        utils.init_plugin({ setup = true })
+
+        -- This test exists to confirm that the previous
+        -- test's success wasn't a silent failure.
+        local exists = utils.global_mapping_exists("n", binding)
+        assert(exists, "could not find global mapping " .. binding)
+    end)
+
+    it("dailies bindings can be disabled by setting them to false", function()
+        -- Remove binding created by other tests.
+        local binding = "<Leader>ndN"
+        if utils.global_mapping_exists("n", binding) then
+            vim.api.nvim_del_keymap("n", binding)
+        end
+
+        -- Configure plugin to set up _no_ key bindings.
+        utils.init_plugin({
+            setup = { extensions = { dailies = { bindings = false } } },
+        })
+
+        local exists = utils.global_mapping_exists("n", binding)
+        assert(not exists, "found global mapping " .. binding .. " despite disabling it")
+    end)
+
+    it("dailies bindings can be disabled by setting core bindings to false", function()
+        -- Remove binding created by other tests.
+        local binding = "<Leader>ndN"
+        if utils.global_mapping_exists("n", binding) then
+            vim.api.nvim_del_keymap("n", binding)
+        end
+
+        -- Configure plugin to set up _no_ key bindings.
+        utils.init_plugin({
+            setup = { bindings = false },
+        })
+
+        local exists = utils.global_mapping_exists("n", binding)
+        assert(not exists, "found global mapping " .. binding .. " despite disabling it")
+    end)
+
+    it("default binding for capture today is <Leader>ndN", function()
+        -- Remove binding created by other tests.
+        local binding = "<Leader>ndN"
+        if utils.global_mapping_exists("n", binding) then
+            vim.api.nvim_del_keymap("n", binding)
+        end
+
+        -- Configure plugin to set up key bindings.
+        utils.init_plugin({ setup = true })
+
+        -- This test exists to confirm that the previous
+        -- test's success wasn't a silent failure.
+        local exists = utils.global_mapping_exists("n", binding)
+        assert(exists, "could not find global mapping " .. binding)
+    end)
 end)

--- a/spec/utils.lua
+++ b/spec/utils.lua
@@ -309,7 +309,7 @@ end
 ---If `wait` provided, schedules mapping and waits N milliseconds.
 ---@param mode org-roam.config.NvimMode
 ---@param lhs string
----@param opts? {buf?:integer, wait?:integer}
+---@param opts? {buf?:integer, wait?:integer, prefix?:string}
 function M.trigger_mapping(mode, lhs, opts)
     opts = opts or {}
     if opts.prefix then


### PR DESCRIPTION
The docs say this:

> To disable all bindings, set the bindings field to false

but the keybindings code accessed `config.bindings.prefix` unconditionally, causing a type error if `config.bindings` is the boolean value `false`. This PR fixes this by fetching `prefix` from the local `bindings` variable, which defaults to `{}` if a false value was configured.

We perform the same fix for the dailies extension. It's a bit unclear what happens in this case:
```lua
require("org-roam").setup({
  -- ...
  bindings = false, -- `bindings.prefix` no longer exists.
  extensions = {
    dailies = {
      bindings = {
        goto_tomorrow = "<prefix>ndt", -- what happens here?
      },
    },
  },
})
```
My understanding of the code is that `<prefix>` will remain unexpanded in this case.