### PR TITLE
Set filetype for select-node windows.

### DIFF
--- a/lua/org-roam/core/ui/select.lua
+++ b/lua/org-roam/core/ui/select.lua
@@ -303,6 +303,7 @@ function M:open()
             bufopts = {
                 offset = 1,
                 modifiable = true,
+                filetype = "org-roam-select",
             },
             winopts = {
                 cursorline = false,


### PR DESCRIPTION
I use the [lualine](https://github.com/nvim-lualine/lualine.nvim) plugin to give all my buffers a [winbar.](https://neovim.io/doc/user/options.html#'winbar') This bar reduces their height  by 1, which the select-node buffer doesn't take into account when calculating its height. The consequence is that the last option in the selection menu is out of view.

Lualine allows the user to selectively [disable](https://github.com/nvim-lualine/lualine.nvim?tab=readme-ov-file#disabling-lualine) it for certain filetypes and buftypes. This PR simply sets the filetype on the select buffer to `org-roam-select` so I can disable the winbar for this menu.