### PR TITLE
fix: broken calendar dialog due to refactor in nvim-orgmode

### DIFF
--- a/lua/org-roam/extensions/dailies.lua
+++ b/lua/org-roam/extensions/dailies.lua
@@ -67,7 +67,7 @@ local function roam_dailies_files(roam)
             local filename = vim.fn.fnamemodify(entry.filename, ":t:r")
             local ext = vim.fn.fnamemodify(entry.filename, ":e")
             local is_org = ext == "org" or ext == "org_archive"
-            local is_date = Date.is_valid_date(filename) ~= nil
+            local is_date = Date.is_valid_date_string(filename) ~= nil
             return entry.type == "file" and is_org and is_date
         end)
         :map(function(entry)


### PR DESCRIPTION
The breaking commit is
<https://github.com/nvim-orgmode/orgmode/blob/62a4106b5072e934062acbd6f4213f89d998cce4/lua/orgmode/objects/date.lua#L331-L335>, a refactor of the `Date` class that renamed a method from `is_valid_date()` to `is_valid_date_string()`.