### PR TITLE
Set certain bindings only in org files

### DIFF
--- a/README.org
+++ b/README.org
@@ -81,24 +81,25 @@ Requires *neovim 0.9.4+*.
 
 ** Bindings
 
-   | Name                     | Keybinding    | Description                                                               |
-   |--------------------------+---------------+---------------------------------------------------------------------------|
-   | add_alias                | =<Leader>naa= | Adds an alias to the node under cursor.                                   |
-   | add_origin               | =<Leader>noa= | Adds an origin to the node under cursor.                                  |
-   | capture                  | =<Leader>nc=  | Opens org-roam capture window.                                            |
-   | complete_at_point        | =<Leader>n.=  | Completes the node under cursor.                                          |
-   | find_node                | =<Leader>nf=  | Finds node and moves to it, creating it if it does not exist.             |
-   | goto_next_node           | =<Leader>nn=  | Goes to the next node in sequence (via origin) for the node under cursor. |
-   | goto_prev_node           | =<Leader>np=  | Goes to the prev node in sequence (via origin) for the node under cursor. |
-   | insert_node              | =<Leader>ni=  | Inserts node at cursor position, creating it if it does not exist.        |
-   | insert_node_immediate    | =<Leader>nm=  | Same as =insert_node=, but skips opening capture buffer.                  |
-   | quickfix_backlinks       | =<Leader>nq=  | Opens the quickfix menu for backlinks to the current node under cursor.   |
-   | remove_alias             | =<Leader>nar= | Removes an alias from the node under cursor.                              |
-   | remove_origin            | =<Leader>nor= | Removes the origin from the node under cursor.                            |
-   | toggle_roam_buffer       | =<Leader>nl=  | Toggles the org-roam node-view buffer for the node under cursor.          |
-   | toggle_roam_buffer_fixed | =<Leader>nb=  | Toggles a fixed org-roam node-view buffer for a selected node.            |
+| Name                     | Keybinding    | Filetype | Description                                                               |
+|--------------------------+---------------+----------+---------------------------------------------------------------------------|
+| capture                  | =<Leader>nc=  | Global   | Opens org-roam capture window.                                            |
+| find_node                | =<Leader>nf=  | Global   | Finds node and moves to it, creating it if it does not exist.             |
+| add_alias                | =<Leader>naa= | Org      | Adds an alias to the node under cursor.                                   |
+| add_origin               | =<Leader>noa= | Org      | Adds an origin to the node under cursor.                                  |
+| complete_at_point        | =<Leader>n.=  | Org      | Completes the node under cursor.                                          |
+| goto_next_node           | =<Leader>nn=  | Org      | Goes to the next node in sequence (via origin) for the node under cursor. |
+| goto_prev_node           | =<Leader>np=  | Org      | Goes to the prev node in sequence (via origin) for the node under cursor. |
+| insert_node              | =<Leader>ni=  | Org      | Inserts node at cursor position, creating it if it does not exist.        |
+| insert_node_immediate    | =<Leader>nm=  | Org      | Same as =insert_node=, but skips opening capture buffer.                  |
+| quickfix_backlinks       | =<Leader>nq=  | Org      | Opens the quickfix menu for backlinks to the current node under cursor.   |
+| remove_alias             | =<Leader>nar= | Org      | Removes an alias from the node under cursor.                              |
+| remove_origin            | =<Leader>nor= | Org      | Removes the origin from the node under cursor.                            |
+| toggle_roam_buffer       | =<Leader>nl=  | Org      | Toggles the org-roam node-view buffer for the node under cursor.          |
+| toggle_roam_buffer_fixed | =<Leader>nb=  | Org      | Toggles a fixed org-roam node-view buffer for a selected node.            |
 
 *** Dailies Extension
+NOTE: All dailies keybindings are global
 
     | Name              | Keybinding    | Description                                     |
     |-------------------+---------------+-------------------------------------------------|

--- a/doc/org-roam.txt
+++ b/doc/org-roam.txt
@@ -237,6 +237,8 @@ ADD ALIAS ~
 
 Adds an alias to the node under cursor.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>naa`.
 
 >lua
@@ -251,6 +253,8 @@ Takes a string representing the keybinding. Defaults to `<Leader>naa`.
 ADD ORIGIN ~
 
 Adds an origin to the node under cursor.
+
+By default only available in org files.
 
 Takes a string representing the keybinding. Defaults to `<Leader>noa`.
 
@@ -284,6 +288,8 @@ Completes the node under cursor by searching for a node with matching title or
 alias. If exactly one match is found, the text under cursor is replaced with
 the link; otherwise, a selection dialog pops up to pick the node.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>n.`.
 
 >lua
@@ -316,6 +322,8 @@ Takes a string representing the keybinding. Defaults to `<Leader>nf`.
 GOTO NEXT NODE ~
 
 Goes to the next node sequentially based on origin of the node under cursor.
+
+By default only available in org files.
 
 If more than one node has the node under cursor as its origin, a selection
 dialog is displayed to choose the node.
@@ -351,6 +359,8 @@ INSERT NODE ~
 
 Inserts a link at cursor position to a node by title or alias.
 
+By default only available in org files.
+
 If the node does not exist, opens a capture buffer for the new node using the
 title.
 
@@ -370,6 +380,8 @@ INSERT NODE IMMEDIATE ~
 Inserts a link at cursor position to a node by title or alias. Unlike
 `insert_node`, this does not open a capture buffer if a new node is created.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>nm`.
 
 >lua
@@ -386,6 +398,8 @@ QUICKFIX BACKLINKS ~
 Opens the quickfix list, populating it with backlinks for the node under
 cursor.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>nq`.
 
 >lua
@@ -401,6 +415,8 @@ REMOVE ALIAS ~
 
 Removes an alias from the node under cursor.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>nar`.
 
 >lua
@@ -415,6 +431,8 @@ Takes a string representing the keybinding. Defaults to `<Leader>nar`.
 REMOVE ORIGIN ~
 
 Removes the origin from the node under cursor.
+
+By default only available in org files.
 
 Takes a string representing the keybinding. Defaults to `<Leader>nor`.
 
@@ -433,6 +451,8 @@ Opens the roam buffer for the node under cursor, updating the buffer when the
 cursor moves to a different node. See the user interface
 |org-roam-org-roam-buffer| section for details.
 
+By default only available in org files.
+
 Takes a string representing the keybinding. Defaults to `<Leader>nl`.
 
 >lua
@@ -449,6 +469,8 @@ TOGGLE ROAM BUFFER FIXED ~
 Opens the roam buffer for a specific node, and will not change as the cursor
 moves across nodes. See the user interface |org-roam-org-roam-buffer| section
 for details.
+
+By default only available in org files.
 
 Takes a string representing the keybinding. Defaults to `<Leader>nb`.
 
@@ -1020,6 +1042,9 @@ Takes a boolean. Defaults to `false`.
   toggle_(roambufferfixed)   <Leader>nb    Toggles a fixed org-roam node-view buffer for a selected node.
 All these bindings use by default the _*prefix_ alias and can be changed all at
 once by modifying `bindings.prefix`.
+
+Only `capture` and `find` are global mappings, the rest are only bound to
+`FileType=org`
 
 
 DAILIES EXTENSION                        *org-roam-bindings-dailies-extension*

--- a/lua/org-roam/setup/keybindings.lua
+++ b/lua/org-roam/setup/keybindings.lua
@@ -297,9 +297,8 @@ local function create_org_file_specific_maps(roam)
         pattern = { "org" },
         callback = function()
             assign_org_ft_keybindings(roam)
-            vim.keymap.set("n", "dd", function() end, { buffer = true })
         end,
-        desc = "Delete entry from Quickfix list",
+        desc = "Create org file specific keybinds for org roam",
     })
 end
 

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -22,6 +22,9 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -49,6 +52,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.add_alias, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = bufnr,
         })
 
         assert.are.same({
@@ -102,6 +106,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.remove_alias, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         assert.are.same({
@@ -154,6 +159,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.add_origin, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         assert.are.same({
@@ -204,6 +210,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.remove_origin, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         assert.are.same({
@@ -252,6 +259,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.goto_prev_node, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Review that we moved to the origin
@@ -290,6 +298,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.goto_next_node, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Review that we moved to the next node
@@ -345,6 +354,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.goto_next_node, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Review that we moved to the next node
@@ -384,6 +394,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.quickfix_backlinks, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Verify the quickfix contents
@@ -416,6 +427,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.toggle_roam_buffer, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -445,6 +457,9 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -459,6 +474,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.toggle_roam_buffer_fixed, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = bufnr,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -489,6 +505,8 @@ describe("org-roam.setup.keybindings", function()
             },
         })
         local prefix = roam.config.bindings.prefix
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
 
         -- Ensure loading is done
         roam.database:load():wait()
@@ -506,6 +524,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.complete_at_point, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = bufnr,
         })
 
         -- Verify we have switched to the appropriate buffer
@@ -528,6 +547,7 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -744,6 +764,9 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -758,6 +781,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.insert_node, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = bufnr,
         })
 
         -- Verify we inserted the link
@@ -778,6 +802,8 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -805,6 +831,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.insert_node, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = bufnr,
         })
 
         -- Verify we inserted the link, replacing the visual selection
@@ -827,6 +854,9 @@ describe("org-roam.setup.keybindings", function()
         })
         local prefix = roam.config.bindings.prefix
 
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
+
         -- Ensure loading is done
         roam.database:load():wait()
 
@@ -839,6 +869,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.insert_node_immediate, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Verify we inserted the link to the new node
@@ -859,6 +890,10 @@ describe("org-roam.setup.keybindings", function()
                 },
             },
         })
+
+        local bufnr = vim.api.nvim_get_current_buf()
+        vim.bo[bufnr].filetype = "org"
+
         local prefix = roam.config.bindings.prefix
 
         -- Ensure loading is done
@@ -881,6 +916,7 @@ describe("org-roam.setup.keybindings", function()
         utils.trigger_mapping("n", roam.config.bindings.insert_node_immediate, {
             wait = utils.wait_time(),
             prefix = prefix,
+            buf = 0,
         })
 
         -- Verify we inserted the link to the new node


### PR DESCRIPTION
Hello! Awesome plugin!

I wanted to try out a quick change where only certain keybinds were set
globally, and the rest were set only in the org filetype. This also meant that
it was easier to use the `keymap.set` api instead of the `nvim_set_keymap` but I
can change that if you want.

Definitely down to restructure or refactor however you'd like, and definitely
let me know if I missed anything!

Thanks!
