### PR TITLE
Fix insert_node_immediate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,11 @@ jobs:
       matrix:
         # NOTE: Nightly disabled until neovim/neovim#30792 is fixed!
         #       Once it is fixed, add "nightly" back to version list.
-        version: [v0.9.4, v0.9.5, v0.10.2, v0.10.3]
+        version: [v0.10.2, v0.10.3, v0.10.4]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            version: v0.10.3
+            version: v0.10.4
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/spec/minimal_init.lua
+++ b/spec/minimal_init.lua
@@ -65,10 +65,13 @@ local plugins = {
 for _, plugin in ipairs(plugins) do
     -- If plugin not yet downloaded, do that now
     if vim.fn.isdirectory(plugin.path) == 0 then
-        report("Downloading "
-            .. plugin.name
-            .. (plugin.branch and (" @ " .. plugin.branch) or "")
-            .. " into: " .. plugin.path)
+        report(
+            "Downloading "
+                .. plugin.name
+                .. (plugin.branch and (" @ " .. plugin.branch) or "")
+                .. " into: "
+                .. plugin.path
+        )
         local cmd = { "git", "clone", "--depth=1" }
 
         -- If given a specific branch, clone that

--- a/spec/minimal_init.lua
+++ b/spec/minimal_init.lua
@@ -8,9 +8,17 @@ if vim.endswith(cwd, "lua") or vim.endswith(cwd, "lua/") or vim.endswith(cwd, "l
     cwd = vim.fs.dirname(cwd)
 end
 
----@type string|false
-local report_enabled = vim.fn.getenv("ROAM_TEST_REPORT")
-if report_enabled == vim.NIL or vim.trim(report_enabled):lower() == "false" then
+---@param name string
+---@return string|nil
+local function getenv(name)
+    local value = vim.fn.getenv(name)
+    if value ~= vim.NIL then
+        return value
+    end
+end
+
+local report_enabled = getenv("ROAM_TEST_REPORT") or false
+if not report_enabled or vim.trim(report_enabled):lower() == "false" then
     report_enabled = false
 end
 local function report(...)
@@ -23,6 +31,7 @@ end
 ---@field name string
 ---@field path string
 ---@field repo string
+---@field branch? string|vim.NIL
 ---@field config? fun()
 
 -- List of plugins to process. Order matters!
@@ -40,6 +49,7 @@ local plugins = {
         name = "orgmode",
         path = cwd .. "/vendor/orgmode.nvim",
         repo = "https://github.com/nvim-orgmode/orgmode",
+        branch = getenv("ROAM_TEST_ORGMODE_BRANCH"),
         config = function()
             -- Setup orgmode
             report("Running orgmode setup")
@@ -55,14 +65,23 @@ local plugins = {
 for _, plugin in ipairs(plugins) do
     -- If plugin not yet downloaded, do that now
     if vim.fn.isdirectory(plugin.path) == 0 then
-        report("Downloading " .. plugin.name .. " into: " .. plugin.path)
-        vim.fn.system({
-            "git",
-            "clone",
-            "--depth=1",
-            plugin.repo,
-            plugin.path,
-        })
+        report("Downloading "
+            .. plugin.name
+            .. (plugin.branch and (" @ " .. plugin.branch) or "")
+            .. " into: " .. plugin.path)
+        local cmd = { "git", "clone", "--depth=1" }
+
+        -- If given a specific branch, clone that
+        if plugin.branch then
+            table.insert(cmd, "--branch")
+            table.insert(cmd, plugin.branch)
+            table.insert(cmd, "--single-branch")
+        end
+
+        table.insert(cmd, plugin.repo)
+        table.insert(cmd, plugin.path)
+
+        vim.fn.system(cmd)
     end
 
     -- Add plugin to our runtime path

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -538,9 +538,9 @@ describe("org-roam.setup.keybindings", function()
 
         -- Select the default template
         utils.mock_vim_inputs({
-            confirm = 0,                   -- confirm no for refile
+            confirm = 0, -- confirm no for refile
             getchar = vim.fn.char2nr("d"), -- select "d" template
-            input = "Some title",          -- input "Some title" on title prompt
+            input = "Some title", -- input "Some title" on title prompt
         })
 
         -- Trigger the keybinding and wait a bit
@@ -594,7 +594,7 @@ describe("org-roam.setup.keybindings", function()
 
         -- Select the default template
         utils.mock_vim_inputs({
-            confirm = 0,                   -- confirm no for refile
+            confirm = 0, -- confirm no for refile
             getchar = vim.fn.char2nr("d"), -- select "d" template
         })
 

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -538,9 +538,9 @@ describe("org-roam.setup.keybindings", function()
 
         -- Select the default template
         utils.mock_vim_inputs({
-            confirm = 0, -- confirm no for refile
+            confirm = 0,                   -- confirm no for refile
             getchar = vim.fn.char2nr("d"), -- select "d" template
-            input = "Some title", -- input "Some title" on title prompt
+            input = "Some title",          -- input "Some title" on title prompt
         })
 
         -- Trigger the keybinding and wait a bit
@@ -594,7 +594,7 @@ describe("org-roam.setup.keybindings", function()
 
         -- Select the default template
         utils.mock_vim_inputs({
-            confirm = 0, -- confirm no for refile
+            confirm = 0,                   -- confirm no for refile
             getchar = vim.fn.char2nr("d"), -- select "d" template
         })
 
@@ -844,6 +844,7 @@ describe("org-roam.setup.keybindings", function()
         -- Verify we inserted the link to the new node
         local lines = utils.read_buffer()
         local _, _, id = string.find(lines[1], "%[%[id:([^]]+)]%[new node]]")
+        assert(id, "could not find id of newly-inserted node; line = '" .. lines[1] .. "'")
         assert.are.same({ "[[id:" .. id .. "][new node]]" }, lines)
     end)
 
@@ -886,7 +887,7 @@ describe("org-roam.setup.keybindings", function()
         -- Verify we inserted the link to the new node
         local lines = utils.read_buffer()
         local _, _, id = string.find(lines[1], "%[%[id:([^]]+)]%[[^]]+]]")
-        assert(id, "could not find id of newly-inserted node")
+        assert(id, "could not find id of newly-inserted node; line = '" .. lines[1] .. "'")
         assert.are.same({ "some [[id:" .. id .. "][series of text on multiple]] lines" }, lines)
     end)
 


### PR DESCRIPTION
Tests fail locally and I noticed messaging about failing to refile during the test, so may be due to nvim-orgmode changes.