### PR TITLE
draft: test support for node_display_template

### DIFF
--- a/lua/org-roam/config.lua
+++ b/lua/org-roam/config.lua
@@ -234,6 +234,13 @@ local DEFAULT_CONFIG = {
             unique = false,
         },
     },
+
+    ---Node Display formatting used for completions in node-find
+    ---Available template fields: title, alias, tags, separator
+    ---You can specify a max lenght for the field e.g. {title:10}
+    ---@type string
+    -- node_display_template = "{title}",
+    node_display_template = "{title:50} {separator} {tags}",
 }
 
 ---Global configuration settings leveraged through org-roam.


### PR DESCRIPTION
An initial attempt for supporting this https://github.com/chipsenkbeil/org-roam.nvim/issues/82

I'm not very familiar with lua so it's likely I missed a better way to do this, but happy to change it 

It's not fully ready, there are a few things which i'm unsure about and would appreciate your thoughts:

- in main, a node with aliases is inserted len(alias) + 1 times into the picker as long as they have different aliases, this version would remove that, and whether to show the alias or not is set on the `node_display_template`, but i'm not sure if that's a good idea
- Are there any other fields that would be worth supporting? right now it's a short list of hardcoded options only
- I tried but haven't to make this work nicely with the picker's ui highlighting, so if a node has tags or not ends up changing how the line looks because of the filler `...` chars and highlighting on `:` chars
