### PR TITLE
fix: activate last window after closing selection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         # NOTE: Nightly disabled until neovim/neovim#30792 is fixed!
         #       Once it is fixed, add "nightly" back to version list.
-        version: [v0.10.2, v0.10.3, v0.10.4]
+        version: [v0.10.2, v0.10.3, v0.10.4, v0.11.0]
         os: [ubuntu-latest]
         include:
           - os: windows-latest

--- a/lua/org-roam/core/ui/select.lua
+++ b/lua/org-roam/core/ui/select.lua
@@ -455,6 +455,8 @@ function M:close()
     if window then
         window:close()
     end
+
+    pcall(vim.api.nvim_set_current_win, self.__state.last_win)
 end
 
 ---Returns true if the selection dialog is open.

--- a/lua/org-roam/core/ui/select.lua
+++ b/lua/org-roam/core/ui/select.lua
@@ -106,6 +106,7 @@ end)()
 ---@field items table #raw items available for selection (non-filtered)
 ---@field init_input string #initial text to supply at the beginning
 ---@field auto_select boolean #if true, will select automatically if only one item (filtered) based on init_input
+---@field refocus_window boolean #if true, focus the window active before node selection
 ---@field allow_select_missing boolean #if true, enables selecting non-existent items
 ---@field cancel_on_no_init_matches boolean #if true, cancels if input provided and no matches found
 ---@field bindings org-roam.core.ui.select.Bindings #bindings associated with the window
@@ -133,6 +134,7 @@ M.__index = M
 ---@field init_input? string
 ---@field auto_select? boolean
 ---@field allow_select_missing? boolean
+---@field skip_window_refocus? boolean
 ---@field cancel_on_no_init_matches? boolean
 ---@field bindings? {down?:string|string[], up?:string|string[], select?:string|string[], select_missing?:string|string[]}
 ---@field format? fun(item:any):string
@@ -201,6 +203,7 @@ function M:new(opts)
         init_input = opts.init_input or "",
         auto_select = opts.auto_select or false,
         allow_select_missing = allow_select_missing,
+        refocus_window = opts.skip_window_refocus ~= true,
         cancel_on_no_init_matches = cancel_on_no_init_matches,
         bindings = vim.tbl_deep_extend("keep", bindings, default_bindings),
         format = format,
@@ -456,7 +459,9 @@ function M:close()
         window:close()
     end
 
-    pcall(vim.api.nvim_set_current_win, self.__state.last_win)
+    if self.__params.refocus_window then
+        pcall(vim.api.nvim_set_current_win, self.__state.last_win)
+    end
 end
 
 ---Returns true if the selection dialog is open.

--- a/lua/org-roam/ui/node-buffer.lua
+++ b/lua/org-roam/ui/node-buffer.lua
@@ -135,7 +135,7 @@ local function roam_toggle_fixed_buffer(roam, opts)
             toggle_node_buffer(opts.id)
         else
             roam.ui
-                .select_node()
+                .select_node({ skip_window_refocus = opts.focus })
                 :on_choice(function(choice)
                     toggle_node_buffer(choice.id)
                 end)

--- a/lua/org-roam/utils.lua
+++ b/lua/org-roam/utils.lua
@@ -117,7 +117,7 @@ function M.expr_under_cursor(opts)
     -- if we are in an orgmode buffer, otherwise
     -- defaulting back to the vim word under cursor
     local word = vim.fn.expand("<cword>")
-    if vim.api.nvim_buf_get_option(bufnr, "filetype") == "org" then
+    if vim.bo[bufnr].filetype == "org" then
         ---@type TSNode|nil
         local ts_node = vim.treesitter.get_node()
         if ts_node and ts_node:type() == "expr" then

--- a/spec/setup_keybindings_spec.lua
+++ b/spec/setup_keybindings_spec.lua
@@ -443,6 +443,11 @@ describe("org-roam.setup.keybindings", function()
                 database = {
                     path = utils.join_path(directory, "db"),
                 },
+                ui = {
+                    node_buffer = {
+                        focus_on_toggle = true,
+                    },
+                },
             },
         })
         local prefix = roam.config.bindings.prefix


### PR DESCRIPTION
Fixes some of the strange behavior described [here](https://github.com/chipsenkbeil/org-roam.nvim/issues/54#issuecomment-2170809400): After closing the selection window, the cursor jumps back into the last selected window, as expected by the user, instead of some arbitrary window determined somehow by Neovim.

This PR also fixes a deprecation warning in the utils module.