### PR TITLE
fix: Remove deprecation warning

### DIFF
--- a/lua/org-roam/database/loader.lua
+++ b/lua/org-roam/database/loader.lua
@@ -29,7 +29,7 @@ function M:new(opts)
 
     instance.path = {
         database = opts.database,
-        files = vim.tbl_flatten({ opts.files }),
+        files = vim.iter(opts.files):flatten():totable(),
     }
 
     -- For file specified, check if they are explicitly


### PR DESCRIPTION
Using both neovim 0.11 and 0.12-nightly I get the following warning

```
WARNING vim.tbl_flatten is deprecated. Feature will be removed in Nvim 0.13
```