### PR TITLE
Insert links after the cursor rather than before

### DIFF
--- a/lua/org-roam/api/node.lua
+++ b/lua/org-roam/api/node.lua
@@ -443,13 +443,21 @@ local function roam_insert(roam, opts)
             end
         end
 
+        local has_content = string.len(vim.api.nvim_buf_get_lines(bufnr, start_row, start_row + 1, true)[1]) > 0
+        if has_content and start_col == end_col then
+            start_col = start_col + 1
+            end_col = start_col
+        end
         -- Replace or insert the link
+        local link_text = string.format("[[id:%s][%s]]", node.id, label or node.title)
         vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, {
-            string.format("[[id:%s][%s]]", node.id, label or node.title),
+            link_text,
         })
 
         -- Force ourselves back into normal mode
         vim.cmd.stopinsert()
+        -- Set cursor to after the link
+        pcall(vim.api.nvim_win_set_cursor, winnr, { start_row + 1, start_col + string.len(link_text) })
     end
 
     return Promise.new(function(resolve)

--- a/spec/api_node_spec.lua
+++ b/spec/api_node_spec.lua
@@ -175,9 +175,10 @@ describe("org-roam.api.node", function()
             end
         end)
 
-        -- Move cursor to the bottom of the buffer, in front of the text
+        -- Move cursor to the end of the last line in the buffer
         local row = vim.api.nvim_buf_line_count(0)
-        vim.api.nvim_win_set_cursor(0, { row, 0 })
+        local col = utils.cursor_end_of_line_col(row)
+        vim.api.nvim_win_set_cursor(0, { row, col })
 
         -- Trigger node insertion, which will bring up the dialog
         local id = roam.api.insert_node():wait()
@@ -196,7 +197,7 @@ describe("org-roam.api.node", function()
             ":END:",
             "#+FILETAGS: :one:",
             "",
-            "[[id:1][one]][[id:2]]",
+            "[[id:2]][[id:1][one]]",
         }, utils.read_buffer())
     end)
 
@@ -221,9 +222,10 @@ describe("org-roam.api.node", function()
             return helpers.pick_with_label("some test alias")
         end)
 
-        -- Move cursor to the bottom of the buffer, in front of the text
+        -- Move cursor to the end of the last line in the buffer
         local row = vim.api.nvim_buf_line_count(0)
-        vim.api.nvim_win_set_cursor(0, { row, 0 })
+        local col = utils.cursor_end_of_line_col(row)
+        vim.api.nvim_win_set_cursor(0, { row, col })
 
         -- Trigger node insertion, which will bring up the dialog
         local id = roam.api.insert_node():wait()
@@ -239,7 +241,7 @@ describe("org-roam.api.node", function()
             ":END:",
             "#+FILETAGS: :one:",
             "",
-            "[[id:test-node-id][some test alias]][[id:2]]",
+            "[[id:2]][[id:test-node-id][some test alias]]",
         }, utils.read_buffer())
     end)
 
@@ -260,9 +262,10 @@ describe("org-roam.api.node", function()
             return "some custom node"
         end)
 
-        -- Move cursor to the bottom of the buffer, in front of the text
+        -- Move cursor to the end of the last line in the buffer
         local row = vim.api.nvim_buf_line_count(0)
-        vim.api.nvim_win_set_cursor(0, { row, 0 })
+        local col = utils.cursor_end_of_line_col(row)
+        vim.api.nvim_win_set_cursor(0, { row, col })
 
         -- Trigger node insertion, which will bring up the dialog
         local id = roam.api.insert_node()
@@ -290,7 +293,7 @@ describe("org-roam.api.node", function()
             ":END:",
             "#+FILETAGS: :one:",
             "",
-            "[[id:" .. id .. "][some custom node]][[id:2]]",
+            "[[id:2]][[id:" .. id .. "][some custom node]]",
         }, utils.read_buffer())
     end)
 
@@ -311,9 +314,10 @@ describe("org-roam.api.node", function()
             return "some custom node"
         end)
 
-        -- Move cursor to the bottom of the buffer, in front of the text
+        -- Move cursor to the end of the last line in the buffer
         local row = vim.api.nvim_buf_line_count(0)
-        vim.api.nvim_win_set_cursor(0, { row, 0 })
+        local col = utils.cursor_end_of_line_col(row)
+        vim.api.nvim_win_set_cursor(0, { row, col })
 
         -- Trigger node insertion, which will bring up the dialog
         local id = roam.api.insert_node({
@@ -349,7 +353,7 @@ describe("org-roam.api.node", function()
             ":END:",
             "#+FILETAGS: :one:",
             "",
-            "[[id:" .. id .. "][some custom node]][[id:2]]",
+            "[[id:2]][[id:" .. id .. "][some custom node]]",
         }, utils.read_buffer())
     end)
 
@@ -365,9 +369,10 @@ describe("org-roam.api.node", function()
             return "some custom node"
         end)
 
-        -- Move cursor to the bottom of the buffer, in front of the text
+        -- Move cursor to the end of the last line in the buffer
         local row = vim.api.nvim_buf_line_count(0)
-        vim.api.nvim_win_set_cursor(0, { row, 0 })
+        local col = utils.cursor_end_of_line_col(row)
+        vim.api.nvim_win_set_cursor(0, { row, col })
 
         -- Trigger node insertion, which will not bring up the
         -- selection dialog as it's immediate
@@ -384,7 +389,7 @@ describe("org-roam.api.node", function()
             ":END:",
             "#+FILETAGS: :one:",
             "",
-            "[[id:" .. id .. "][some custom node]][[id:2]]",
+            "[[id:2]][[id:" .. id .. "][some custom node]]",
         }, utils.read_buffer())
     end)
 

--- a/spec/utils.lua
+++ b/spec/utils.lua
@@ -683,4 +683,12 @@ function M.unpatch_vim_cmd()
     vim.cmd = VIM_CMD
 end
 
+--- Computes the cursor position such that it is at the end of the line
+--- of the current buffer and the given row
+--- @param row integer (one-based)
+--- @return integer (zero-based)
+function M.cursor_end_of_line_col(row)
+    return string.len(vim.api.nvim_buf_get_lines(0, row - 1, row, true)[1]) - 1
+end
+
 return M


### PR DESCRIPTION
The current insert link behavior places links "before" the cursor (as if going to insert mode). This is awkward when inserting a link while the cursor is at the end of the line, after a trailing space:

Given this cursor position in normal mode:

```
Inserting a 
           ^
```

The current behavior would produce (with a trailing space)

```
Inserting a[[id:...][link]] 
```

With this patch, it would produce

```
Inserting a [[id:...][link]]
```

instead. This is in line with how nvim-orgmode behaves when inserting a link. Additionally, I'm placing the cursor at the end of the link, so `a` will let you continue typing.

The line length check is needed because for empty lines, doing the `+ 1` for the insert location would be out of bounds. If the link is replacing text, it also doesn't change any behavior, except for the cursor placement at the end.

I tried running the included tests locally, and a lot of them seem to fail. But they appear to already be failing on the main branch, so I can't tell if this breaks anything that I didn't catch in my manual testing.