### PR TITLE
feat: custom label formatting in select-node windows.

### DIFF
--- a/DOCS.org
+++ b/DOCS.org
@@ -777,6 +777,50 @@
 
    Configuration settings tied to the user interface.
 
+*** selection dialog
+
+    Bindings tied specifically to the node selection dialog.
+
+**** label
+
+     If nil or not set, each selection item is the unmodified title or alias of a node.
+
+     If set to a function, it is called with each node. It should return either a single
+     string to show for this node in the dialog, or a list of strings that all refer to
+     the same node.
+
+     #+begin_src lua
+     require("org-roam").setup({
+       ui = {
+         select = {
+           ---@type fun(node: org-roam.core.file.Node): string|string[]
+           label = function(node)
+             local format
+             if #node.tags == 0 then
+               format = function(label)
+                 return label
+               end
+             else
+               local tags = table.concat(node.tags, ", ")
+               format = function(label)
+                 return ("(%s) %s"):format(tags, label)
+               end
+             end
+             local labels = {}
+             table.insert(labels, format(node.title))
+             for _,alias in ipairs(node.alias) do
+               -- Avoid repeat of alias that is same as title
+               if alias ~= node.title then
+                 table.insert(labels, format(alias))
+               end
+             end
+             return labels
+           end,
+         },
+       },
+     })
+     #+end_src
+
 *** node view
 
     Bindings tied specifically to the roam buffer.

--- a/lua/org-roam/config.lua
+++ b/lua/org-roam/config.lua
@@ -204,6 +204,24 @@ local DEFAULT_CONFIG = {
     ---Settings tied to the user interface.
     ---@class org-roam.config.UserInterface
     ui = {
+        ---Select-node dialog configuration settings.
+        ---@class org-roam.config.ui.SelectNode
+        select = {
+            ---If not nil, should be a function that takes a node returns a string or
+            ---list of strings to add to the selection dialog.
+            ---If nil, one string is returned for the node title and one for each alias.
+            ---@type fun(node: org-roam.core.file.Node): string|string[]
+            label = function(node)
+                local items = {}
+                table.insert(items, node.title)
+                for _, alias in ipairs(node.aliases) do
+                    if alias ~= node.title then
+                        table.insert(items, alias)
+                    end
+                end
+                return items
+            end,
+        },
         ---Node view buffer configuration settings.
         ---@class org-roam.config.ui.NodeView
         node_buffer = {

--- a/lua/org-roam/ui/select-node.lua
+++ b/lua/org-roam/ui/select-node.lua
@@ -10,6 +10,8 @@ local Select = require("org-roam.core.ui.select")
 ---@param opts {allow_select_missing?:boolean, auto_select?:boolean, exclude?:string[], include?:string[], init_input?:string}
 ---@return org-roam.core.ui.Select
 local function roam_select_node(roam, opts)
+    local get_labels = roam.config.ui.select.label
+
     -- TODO: Make this more optimal. Probably involves supporting
     --       an async function to return items instead of an
     --       item list so we can query the database by name
@@ -28,11 +30,12 @@ local function roam_select_node(roam, opts)
         if not skip then
             local node = roam.database:get_sync(id)
             if node then
-                table.insert(items, { id = id, label = node.title })
-                for _, alias in ipairs(node.aliases) do
-                    -- Avoid repeat of alias that is same as title
-                    if alias ~= node.title then
-                        table.insert(items, { id = id, label = alias })
+                local labels = get_labels(node)
+                if type(labels) == "string" then
+                    table.insert(items, { id = id, label = labels })
+                else
+                    for _, label in ipairs(labels) do
+                        table.insert(items, { id = id, label = label })
                     end
                 end
             end

--- a/spec/ui_select_node_spec.lua
+++ b/spec/ui_select_node_spec.lua
@@ -73,6 +73,31 @@ describe("org-roam.ui.select-node", function()
         }, lines)
     end)
 
+    it("should allow formatting the labels of all nodes", function()
+        local function label(node)
+            return ("%s :%s:"):format(node.title, table.concat(node.tags, ":"))
+        end
+        roam.config.ui.select.label = label
+        roam.database:load():wait()
+        local win = vim.api.nvim_get_current_win()
+
+        -- Load up the selection interface for all nodes
+        roam.ui.select_node():open()
+        utils.wait()
+
+        -- Grab lines from current buffer
+        local lines = read_trimmed_sorted_buf_lines()
+
+        -- Aliases are not included
+        assert.are_not.equal(win, vim.api.nvim_get_current_win())
+        assert.are.same({
+            "", -- line containing filter text
+            "one :one:",
+            "three :three:",
+            "two :two:",
+        }, lines)
+    end)
+
     it("should support limiting to only included node ids", function()
         roam.database:load():wait()
         local win = vim.api.nvim_get_current_win()


### PR DESCRIPTION
This adds a new config `ui.select.label_function` that allows modifying how a node is displayed in the select-node dialog.

This mirrors the emacs org-roam variable [`org-roam-node-display-template`](https://www.orgroam.com/manual.html#Customizing-Node-Completions-1).

Many people ([example](https://org-roam.discourse.group/t/how-to-use-roam-tags-and-or-tags/190/6), [example](https://org-roam.discourse.group/t/my-guidelines-on-tags-with-org-roam-v2/3333)) use this feature to show additional information about a node, e.g. tags and directories.

While the original variable allows much richer customization, e.g. changing font styling, this is just a simple implementation to get some basic functionality going.

Points of contention:
- using a function instead of a template string
- name of the config

I'm open to any suggestion on these points!