### PR TITLE
Extend ui label config to support label vs value distinction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ on:
 env:
   CI: true
   ROAM_DEBUG: true
-  ROAM_TEST_REPORT: false
+  ROAM_TEST_REPORT: true
+  ROAM_TEST_ORGMODE_BRANCH: 0.7.0
   ROAM_WAIT_TIME: 500
 
 jobs:

--- a/DOCS.org
+++ b/DOCS.org
@@ -781,40 +781,61 @@
 
     Bindings tied specifically to the node selection dialog.
 
-**** label
+**** node_to_items
 
-     If nil or not set, each selection item is the unmodified title or alias of a node.
+     Converts an org-roam node into one or more items to display in
+     the select dialog. The function returns either a list of strings
+     that will both populate the selection dialog AND be injected into
+     buffers (e.g. for link descriptions), or returns a list of tables
+     that contain both a =label= (string) and =value= (anything) where
+     the label is displayed in the selection and the value is injected
+     into buffers.
 
-     If set to a function, it is called with each node. It should return either a single
-     string to show for this node in the dialog, or a list of strings that all refer to
-     the same node.
+     By default, this will convert each node into its title and each
+     individual alias.
 
      #+begin_src lua
      require("org-roam").setup({
        ui = {
          select = {
-           ---@type fun(node: org-roam.core.file.Node): string|string[]
-           label = function(node)
-             local format
-             if #node.tags == 0 then
-               format = function(label)
+           ---@type fun(node:org-roam.core.file.Node):org-roam.config.ui.SelectNodeItems
+           node_to_items = function(node)
+             ---@type string[]
+             local items = {}
+
+             local function make_item(label)
+               if #node.tags == 0 then
+                 -- We can pass a string if the label and value
+                 -- are the same
                  return label
-               end
-             else
-               local tags = table.concat(node.tags, ", ")
-               format = function(label)
-                 return ("(%s) %s"):format(tags, label)
-               end
-             end
-             local labels = {}
-             table.insert(labels, format(node.title))
-             for _,alias in ipairs(node.alias) do
-               -- Avoid repeat of alias that is same as title
-               if alias ~= node.title then
-                 table.insert(labels, format(alias))
+               else
+                 local tags = table.concat(node.tags, ", ")
+
+                 -- In the case that the label (displayed) and
+                 -- value (injected) are different, we can pass
+                 -- a table with `label` and `value` back
+                 return {
+                     label = ("(%s) %s"):format(tags, label),
+                     value = label,
+                 }
                end
              end
-             return labels
+
+             -- For the node's title and its aliases, we want
+             -- to create an item where the title/alias is the
+             -- value and we show them alongside tags if they exist
+             --
+             -- This allows us to search tags, but not insert
+             -- tags as part of a link if selected
+             table.insert(items, make_item(node.title))
+             for _, alias in ipairs(node.aliases) do
+                 -- Avoid duplicating the title if the alias is the same
+                 if alias ~= node.title then
+                     table.insert(items, make_item(alias))
+                 end
+             end
+
+             return items
            end,
          },
        },
@@ -1568,6 +1589,7 @@
                 not provided, all nodes will immediately be available.
      - init_input: optional, string representing initial input to provide to
                    the selection dialog, as if the user typed it.
+     - node_to_items: optional, function to convert node to displayed items
 
    Returns:
 

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,8 @@ test-file: ## Run specific test file denoted by FILE environment variable
 		-u spec/minimal_init.lua \
 		-c "lua require('plenary.test_harness').test_directory('spec/$(FILE)', {minimal_init='spec/minimal_init.lua', sequential=true})"
 
+format: ## Uses stylua to format lua files
+	@stylua **/*.lua
+
 clean: ## Cleans out vendor directory
 	@rm -rf vendor/*

--- a/lua/org-roam/api/completion.lua
+++ b/lua/org-roam/api/completion.lua
@@ -86,7 +86,11 @@ local function roam_complete_node_under_cursor(roam, opts)
 
                 -- Replace the text (this will place us into insert mode)
                 vim.api.nvim_buf_set_text(bufnr, row, col, row, col + #selection, {
-                    string.format("[[id:%s][%s]]", node.id, choice.label),
+                    string.format(
+                        "[[id:%s][%s]]",
+                        node.id,
+                        type(choice.value) == "string" and choice.value or choice.label
+                    ),
                 })
 
                 -- Force ourselves back into normal mode

--- a/lua/org-roam/api/node.lua
+++ b/lua/org-roam/api/node.lua
@@ -469,7 +469,8 @@ local function roam_insert(roam, opts)
                 init_input = opts.title,
             })
             :on_choice(function(choice)
-                insert_link(choice.id, choice.label)
+                local label = type(choice.value) == "string" and choice.value or choice.label
+                insert_link(choice.id, label)
                 resolve(choice.id)
             end)
             :on_choice_missing(function(label)

--- a/lua/org-roam/config.lua
+++ b/lua/org-roam/config.lua
@@ -207,14 +207,25 @@ local DEFAULT_CONFIG = {
         ---Select-node dialog configuration settings.
         ---@class org-roam.config.ui.SelectNode
         select = {
-            ---If not nil, should be a function that takes a node returns a string or
-            ---list of strings to add to the selection dialog.
-            ---If nil, one string is returned for the node title and one for each alias.
-            ---@type fun(node: org-roam.core.file.Node): string|string[]
-            label = function(node)
+            ---@alias org-roam.config.ui.SelectNodeItems (string|{label:string, value:any})[]
+            ---
+            ---Converts an org-roam node into one or more items to display in
+            ---the select dialog. The function returns either a list of strings
+            ---that will both populate the selection dialog AND be injected into
+            ---buffers (e.g. for link descriptions), or returns a list of tables
+            ---that contain both a `label` (string) and `value` (anything) where
+            ---the label is displayed in the selection and the value is injected
+            ---into buffers.
+            ---
+            ---By default, this will convert each node into its title and each
+            ---individual alias.
+            ---@type fun(node:org-roam.core.file.Node):org-roam.config.ui.SelectNodeItems
+            node_to_items = function(node)
+                ---@type string[]
                 local items = {}
                 table.insert(items, node.title)
                 for _, alias in ipairs(node.aliases) do
+                    -- Avoid duplicating the title if the alias is the same
                     if alias ~= node.title then
                         table.insert(items, alias)
                     end


### PR DESCRIPTION
@broken-pen here is a followup from your PR. Let me know what you think!

I renamed `label` to `node_to_items` after thinking about it a bit to make it more clear, and the function has to return a list of items that are either a `string` or a `{label:string, value:any}`.

The displayed (and searchable) part is `label` and the part injected when inserting a node or completing is `value` (if it's a string type).