### PR TITLE
fix: only call mpack.decode() once, add locking around Database.load_from_disk()

### DIFF
--- a/lua/org-roam/core/database.lua
+++ b/lua/org-roam/core/database.lua
@@ -116,16 +116,12 @@ function M:load_from_disk(path)
         -- Try to decode the data into Lua and set it as the nodes,
         -- using each potential decoder in turn
         ---@type boolean, table|nil
-        local success, __data = pcall(vim.mpack.decode, data)
-
-        success, __data = pcall(vim.json.decode, data, {
+        local success, __data = pcall(vim.json.decode, data, {
             luanil = { array = true, object = true },
         })
 
         if not success then
-            success, __data = pcall(vim.mpack.decode, data, {
-                luanil = { array = true, object = true },
-            })
+            success, __data = pcall(vim.mpack.decode, data)
         end
 
         if not success or not __data then

--- a/lua/org-roam/database/loader.lua
+++ b/lua/org-roam/database/loader.lua
@@ -17,6 +17,7 @@ local schema = require("org-roam.database.schema")
 ---@field path {database:string, files:string[]}
 ---@field __db org-roam.core.Database #cache of loaded database
 ---@field __files OrgFiles #cache of loaded org files
+---@field __load_state 'loading' | 'loaded' | nil
 local M = {}
 M.__index = M
 
@@ -373,38 +374,48 @@ end
 ---Loads database (or retrieves from cache) asynchronously.
 ---@return OrgPromise<org-roam.core.Database>
 function M:database()
-    return self.__db and Promise.resolve(self.__db)
-        or Promise.new(function(resolve)
-            -- Load our database from disk if it is available
-            io.stat(self.path.database)
-                :next(function()
-                    return Database:load_from_disk(self.path.database)
-                        :next(function(db)
-                            schema:update(db)
-                            self.__db = db
+    if self.__load_state then
+        if self.__load_state == "loading" then
+            self:ensure_loaded()
+        end
+        return Promise.resolve(self.__db)
+    end
 
-                            resolve(db)
-                            return db
-                        end)
-                        :catch(function(err)
-                            log.fmt_error("Failed to load database: %s", err)
+    self.__load_state = "loading"
+    return Promise.new(function(resolve)
+        -- Load our database from disk if it is available
+        io.stat(self.path.database)
+            :next(function()
+                return Database:load_from_disk(self.path.database)
+                    :next(function(db)
+                        schema:update(db)
+                        self.__db = db
+                        self.__load_state = "loaded"
 
-                            -- Set up database with a clean slate instead
-                            local db = Database:new()
-                            schema:update(db)
-                            self.__db = db
+                        resolve(db)
+                        return db
+                    end)
+                    :catch(function(err)
+                        log.fmt_error("Failed to load database: %s", err)
 
-                            resolve(db)
-                        end)
-                end)
-                :catch(function()
-                    local db = Database:new()
-                    schema:update(db)
-                    self.__db = db
+                        -- Set up database with a clean slate instead
+                        local db = Database:new()
+                        schema:update(db)
+                        self.__db = db
+                        self.__load_state = "loaded"
 
-                    return resolve(db)
-                end)
-        end)
+                        resolve(db)
+                    end)
+            end)
+            :catch(function()
+                local db = Database:new()
+                schema:update(db)
+                self.__db = db
+                self.__load_state = "loaded"
+
+                return resolve(db)
+            end)
+    end)
 end
 
 ---Loads database (or retrieves from cache) synchronously.
@@ -413,6 +424,17 @@ end
 function M:database_sync(opts)
     opts = opts or {}
     return self:database():wait(opts.timeout)
+end
+
+---Ensure that the database is fully loaded.
+---@return true?
+function M:ensure_loaded()
+    if self.__load_state == "loaded" then
+        return true
+    end
+    vim.wait(5000, function()
+        return self.__load_state == "loaded"
+    end, 5)
 end
 
 ---Loads org files (or retrieves from cache) asynchronously.


### PR DESCRIPTION
When playing around with database loading, I noticed two issues:

1. `load_from_disk()` supports two formats (mpack and json) and wants to try them in order; for some reason, it tries mpack twice;
2. when using [lazy-loading](https://github.com/folke/lazy.nvim), I noticed that org-roam was reading the entire database twice: once because it was starting up, and once because I was opening the select-node dialog while the initial load hadn't finished yet.

I solved the second issue by copying the mutex logic from [nvim-orgmode's `files/init.lua`](https://github.com/nvim-orgmode/orgmode/blob/f4dde882b924a9a94ce887104dbc6a982ea11ab7/lua/orgmode/files/init.lua#L57-L64) and it seemed to have the desired effect.

No unit tests for this because I'm honestly not sure how to test these behavior nuances without a mocking framework.