### PR TITLE
Support fzf-lua as select-node dialog

### DIFF
--- a/DOCS.org
+++ b/DOCS.org
@@ -845,6 +845,33 @@
      })
      #+end_src
 
+**** annotation
+
+     Adds an annotation to each display item in the select dialog.
+     The function returns either =nil= (meaning no annotation) or
+     a string that will be shown behind the =label= of the item. The
+     annotation is displayed with the highlight groups =hl-PmenuExtra= and
+     =hl-PmenuExtraSel=. This lets you distinguish it from the node title or
+     alias in question.
+
+     By default, no annotation whatsoever is added.
+
+     #+begin_src lua
+     vim.api.nvim_set_hl(0, 'PmenuExtra', { link = 'Comment' })
+     require("org-roam").setup({
+       ui = {
+         select = {
+           ---@type fun(node:org-roam.core.file.Node):string?
+           annotation = function(node)
+             if next(node.tags) then
+               return '#' .. table.concat(node.tags, ' #')
+             end
+           end,
+         },
+       },
+     })
+     #+end_src
+
 *** node view
 
     Bindings tied specifically to the roam buffer.

--- a/lua/org-roam/config.lua
+++ b/lua/org-roam/config.lua
@@ -232,6 +232,15 @@ local DEFAULT_CONFIG = {
                 end
                 return items
             end,
+            ---Adds an annotation to each display item in the select dialog.
+            ---The function returns either nil (meaning no annotation) or
+            ---a string that will be shown behind the `label` of the item. The
+            ---annotation is displayed with the highlight groups `hl-PmenuExtra`
+            ---and `hl-PmenuExtraSel`. This lets you distinguish it from the node
+            ---title or alias in question.
+            ---
+            ---@type (fun(node:org-roam.core.file.Node):string?)?
+            annotation = nil,
         },
         ---Node view buffer configuration settings.
         ---@class org-roam.config.ui.NodeView


### PR DESCRIPTION
Hi! For the past few weeks, I've been privately experimenting with a fork of Org-Roam where the select-node dialog has been replaced with [fzf-lua](https://github.com/ibhagwan/fzf-lua)'s fuzzy-finder interface.

I've also added a config `ui.select.annotation` that mimicks the option `org-roam-node-annotation-function` of [Emacs Org-Roam](https://github.com/org-roam/org-roam/blob/main/org-roam-node.el#L95-L99). It differs from the previously introduced [custom label formatting](https://github.com/chipsenkbeil/org-roam.nvim/pull/100) by using different highlight groups:
- the built-in select-node interface uses the highlight groups `PmenuExtra` and `PmenuExtraSel`;
- the fzf-lua interface always highlights annotations in gray right now.

<img width="400" height="1024" alt="Screenshot built-in select-node dialog with annotations" src="https://github.com/user-attachments/assets/eb1dabc7-5714-4cd4-ada7-4feb33ef6fe1" />
<img width="400" height="1013" alt="Screenshot fzf-lua select-node dialog with annotations" src="https://github.com/user-attachments/assets/8bbcb877-2c44-45bc-93bb-516239420789" />

I've marked this PR as a WIP for now because there are several design decisions involved that I'd like your input on before actually considering merging it. Please consider the current version only a draft :slightly_smiling_face: 

A few design questions that come to my mind:
- Should the code live in `org-roam.core.ui` and `org-roam.ui` or would it better fit into `org-roam.extensions`?
- Similar for the configs: As they are right now or better under `extensions`?
- Are the "annotations" even a feature you want to support in the first place?
- FZF-related options (window style, etc.) right now can only be set through fzf-lua's `setup()` call. Would it make sense to provide a config entry point in `org-roam`?
- I've managed to make the transfer of display items from nvim to fzf fully asynchronous. This ended up getting very messy because we use Orgmode's `OrgPromise` API whereas fzf-lua uses `coroutine`. I'm not sure this is worth the trouble.
- Default options for the FZF dialog should be considered; we can make it look a lot more like the built-in select dialog by default, if we want.

And once all this is settled, we'll have to discuss various coding decisions obviously :sweat_smile: 

Feel free to take your time and as always, thank you for maintaining this awesome plugin!
