### PR TITLE
fix: Use file.lines instead of file.content for sha256 calculation 

### DIFF
--- a/lua/org-roam/core/file.lua
+++ b/lua/org-roam/core/file.lua
@@ -108,7 +108,7 @@ function M:from_org_file(file)
     end
 
     -- Check if we have a cached value for this file specifically
-    local key = vim.fn.sha256(file.content)
+    local key = vim.fn.sha256(table.concat(file.lines, "\n"))
     if CACHE.files[key] and CACHE.hashes[file.filename] == key then
         return CACHE.files[key]
     end

--- a/lua/org-roam/ui/node-buffer/buffer.lua
+++ b/lua/org-roam/ui/node-buffer/buffer.lua
@@ -151,7 +151,7 @@ local function load_lines_at_cursor(roam, path, cursor)
 
             -- Calculate a digest and see if its different
             ---@cast file -nil
-            local sha256 = vim.fn.sha256(file.content)
+            local sha256 = vim.fn.sha256(table.concat(file.lines, "\n"))
             local is_new = not CACHE[key] or CACHE[key].sha256 ~= sha256
 
             -- Update our cache


### PR DESCRIPTION
`file.content` has been deprecated in https://github.com/nvim-orgmode/orgmode/pull/1041

fixes #114 