### PR TITLE
fix: restore window options after visiting a new node

### DIFF
--- a/lua/org-roam/api/node.lua
+++ b/lua/org-roam/api/node.lua
@@ -523,6 +523,9 @@ local function roam_find(roam, opts)
         vim.cmd.edit({ node.file, bang = true })
         vim.cmd.filetype("detect")
 
+        -- Re-trigger user autocmds so window options (number, signcolumn, etc.) are restored
+        vim.cmd("silent doautocmd BufWinEnter")
+
         -- Force ourselves back into normal mode
         vim.cmd.stopinsert()
 


### PR DESCRIPTION
## Merge Order
This PR is independent and can be merged in any order.

## Summary
- Fixes #119
- After `visit_node()` calls `vim.cmd.edit()`, user autocmds that set window options (line numbers, signcolumn, etc.) are not re-triggered
- Adds `doautocmd BufWinEnter` after filetype detect so user autocmds re-apply window-local settings

## Test plan
- Configure Neovim with `number=true` (or other window-local options)
- Use `<Leader>nf` to find/create a new node
- Verify the new buffer has the expected window options (line numbers visible, etc.)