### PR TITLE
fix: open backlinks via vim.cmd.edit to avoid Ex injection

### DIFF
--- a/lua/org-roam/ui/node-buffer/buffer.lua
+++ b/lua/org-roam/ui/node-buffer/buffer.lua
@@ -372,7 +372,7 @@ local function render(roam, this, node, details)
                             })
                             :on_choice(function(winnr)
                                 vim.api.nvim_set_current_win(winnr)
-                                vim.cmd("e " .. backlink_node.file)
+                                vim.cmd.edit(backlink_node.file)
 
                                 -- NOTE: We need to schedule to ensure the file has loaded
                                 --       into the buffer before we try to move the cursor!


### PR DESCRIPTION
Backlinks opened via `vim.cmd("e " .. backlink_node.file)` are vulnerable to injection by a file with a name like "some_note.org | call system('touch hi')"

This is fixed by using `vim.cmd.edit(backlink_node.file)`

Below is a PoC, run it with `nvim --headless --noplugin -u NONE -c "luafile poc.lua"`

```lua
local proof = vim.fn.tempname()
vim.env.PROOF = proof
local name = [[note.org| call system('touch "$PROOF"')]]

local function plant()
    local dir = vim.fn.tempname()
    vim.fn.mkdir(dir, "p")
    local path = vim.fs.joinpath(dir, name)
    vim.fn.writefile({ ":id: poc" }, path)
    return path
end

vim.fn.delete(proof)
pcall(vim.cmd, "e " .. plant()) -- old: vim.cmd("e " .. node.file)
local old = vim.fn.filereadable(proof) == 1

vim.fn.delete(proof)
pcall(vim.cmd.edit, plant()) -- fix: vim.cmd.edit(node.file)
local new = vim.fn.filereadable(proof) == 1

print("vim.cmd('e ' .. file): ran command = " .. tostring(old))
print("vim.cmd.edit(file):    ran command = " .. tostring(new))
vim.fn.delete(proof)
vim.cmd((old and not new) and "cq 0" or "cq 1")
```